### PR TITLE
Extend write results information

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -107,8 +107,8 @@ var CHUNK_SIZE = 65536 * 16; // 64K * 16 = 1024K = 1M
  *   console.error(error);
  * });
  *
- * emitter.on('done', function(success) {
- *   if (success) {
+ * emitter.on('done', function(results) {
+ *   if (results.passedValidation) {
  *     console.log('Success!');
  *   } else {
  *     console.log('Failed!');
@@ -167,7 +167,10 @@ exports.write = function(device, stream, options) {
     }).then(function(results) {
       if (!options.check) {
         return win32.prepare().then(function() {
-          emitter.emit('done', true);
+          emitter.emit('done', {
+            passedValidation: true,
+            sourceChecksum: results.checksum
+          });
         });
       }
 
@@ -204,7 +207,10 @@ exports.write = function(device, stream, options) {
           });
 
       }).tap(win32.prepare).then(function(deviceChecksum) {
-        emitter.emit('done', results.checksum === deviceChecksum);
+        emitter.emit('done', {
+          passedValidation: results.checksum === deviceChecksum,
+          sourceChecksum: results.checksum
+        });
       });
     }).asCallback(callback);
 

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -41,8 +41,9 @@ wary.it('write: should be able to burn data to a file', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(passed) {
-    m.chai.expect(passed).to.be.true;
+  }).then(function(results) {
+    m.chai.expect(results.passedValidation).to.be.true;
+    m.chai.expect(results.sourceChecksum).to.equal('2f73fef');
 
     return Promise.props({
       random1: fs.readFileAsync(images.random1),
@@ -83,8 +84,8 @@ wary.it('check: should eventually be true on success', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(passed) {
-    m.chai.expect(passed).to.be.true;
+  }).then(function(results) {
+    m.chai.expect(results.passedValidation).to.be.true;
   });
 });
 
@@ -107,8 +108,8 @@ wary.it('check: should eventually be false on failure', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(passed) {
-    m.chai.expect(passed).to.be.true;
+  }).then(function(results) {
+    m.chai.expect(results.passedValidation).to.be.true;
     createReadStreamStub.restore();
   });
 });
@@ -128,8 +129,8 @@ wary.it('transform: should be able to decompress an gz image', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(passed) {
-    m.chai.expect(passed).to.be.true;
+  }).then(function(results) {
+    m.chai.expect(results.passedValidation).to.be.true;
 
     return Promise.props({
       real: fs.readFileAsync(images.real),


### PR DESCRIPTION
- Make `done` resolve an object.
- Move validation success boolean to `results.passedValidation`.
- Expose image checksum as `results.sourceChecksum`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>