### PR TITLE
Fix Windows EPERM on GPT drives

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,39 +16,6 @@
 
 'use strict';
 
-var Promise = require('bluebird');
-var fs = Promise.promisifyAll(require('fs'));
-
-/**
- * @summary Erase MBR from a device
- * @function
- * @protected
- *
- * @description
- * Write 512 null bytes at the beginning of a device
- *
- * @param {String} device - device
- * @returns {Promise}
- *
- * @example
- * utils.eraseMBR('/dev/disk2');
- */
-exports.eraseMBR = function(device) {
-  var bufferSize = 512;
-  var buffer = new Buffer(bufferSize);
-  buffer.fill(0);
-  return fs.openAsync(device, 'rs+').then(function(fd) {
-    return fs.writeAsync(fd, buffer, 0, bufferSize, 0).then(function(bytesWritten) {
-      bytesWritten = bytesWritten[0] || bytesWritten;
-      if (bytesWritten !== bufferSize) {
-        throw new Error('Bytes written: ' + bytesWritten + ', expected ' + bufferSize);
-      }
-
-      return fs.closeAsync(fd);
-    });
-  });
-};
-
 /**
  * @summary Get raw device file
  * @function

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -18,11 +18,20 @@
 
 var Promise = require('bluebird');
 var os = require('os');
+var _ = require('lodash');
 var isWindows = os.platform() === 'win32';
 
 if (isWindows) {
   var diskpart = Promise.promisifyAll(require('diskpart'));
 }
+
+var runDiskpartScript = function(script) {
+  return Promise.try(function() {
+    if (isWindows) {
+      return diskpart.evaluateAsync(script);
+    }
+  });
+};
 
 /**
  * @summary Prepare Windows drives
@@ -30,23 +39,45 @@ if (isWindows) {
  * @protected
  *
  * @description
- * This function runs
+ * This function runs cleans the drive, converting it into
+ * a "RAW" device, which no filesystem, so Windows direct
+ * access policies can allow us to arbitrarily write to it.
  *
- * - diskpart `rescan` command.
+ * It will do nothing if not being run in Windows.
+ *
+ * @param {String} device - device
+ * @returns {Promise}
+ *
+ * @example
+ * win32.prepare('\\\\.\\PHYSICALDRIVE1');
+ */
+exports.prepare = function(device) {
+  return Promise.try(function() {
+    var deviceId = _.nth(device.match(/PHYSICALDRIVE(\d+)/i), 1);
+
+    if (deviceId) {
+      return runDiskpartScript([
+        'select disk ' + deviceId,
+        'clean'
+      ]);
+    }
+  });
+};
+
+/**
+ * @summary Rescan Windows drives
+ * @function
+ * @protected
  *
  * It will do nothing if not being run in Windows.
  *
  * @returns {Promise}
  *
  * @example
- * win32.prepare();
+ * win32.rescan();
  */
-exports.prepare = function() {
-  return Promise.try(function() {
-    if (isWindows) {
-      return diskpart.evaluateAsync([
-        'rescan'
-      ]);
-    }
-  });
+exports.rescan = function(device) {
+  return runDiskpartScript([
+    'rescan'
+  ]);
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -131,7 +131,7 @@ exports.write = function(device, stream, options) {
   // causing our checksum comparison to fail.
   denymount(device, function(callback) {
 
-    return utils.eraseMBR(device).then(win32.prepare).then(function() {
+    return win32.prepare(device).then(function() {
       return new Promise(function(resolve, reject) {
         var checksumStream = new CRC32Stream();
 
@@ -166,7 +166,7 @@ exports.write = function(device, stream, options) {
       });
     }).then(function(results) {
       if (!options.check) {
-        return win32.prepare().then(function() {
+        return win32.rescan().then(function() {
           emitter.emit('done', {
             passedValidation: true,
             sourceChecksum: results.checksum
@@ -206,7 +206,7 @@ exports.write = function(device, stream, options) {
             return resolve(checksumStream.hex().toLowerCase());
           });
 
-      }).tap(win32.prepare).then(function(deviceChecksum) {
+      }).tap(win32.rescan).then(function(deviceChecksum) {
         emitter.emit('done', {
           passedValidation: results.checksum === deviceChecksum,
           sourceChecksum: results.checksum

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "crc32-stream": "^0.4.0",
     "denymount": "^2.1.0",
     "dev-null-stream": "0.0.1",
-    "lodash": "^3.10.0",
+    "lodash": "^4.13.1",
     "progress-stream": "^1.1.1",
     "slice-stream2": "^2.0.0",
     "stream-chunker": "^1.2.8"


### PR DESCRIPTION
This commit fixes a sporadic issues observed by a minority of our
Windows users triggered when writing beyond the first 512 bytes of a
drive.

After some experimentation, the issue comes down to writing an image to
a drive previously formatted with a GUID Partition Table. This
technology stores its partition data in various blocks at both the
beginning and end of a drive. MBR, in the other hand, only stores the
partition table in the first block. We were currently only accounting
for MBR drives.

Windows only allows direct write to physical drives if the section we're
writing to is the first block of the drive, or if the drive contains no
file system (a "RAW" drive, as Microsoft describes it).

Since deleting the first block of a GPT drive will not delete all the
partition table information, Windows didn't detect it as "RAW", and
therefore threw `EPERM` when we wrote beyond the first block.

Sadly, doing manual I/O to clean the last blocks of drive was not
possible, since Windows would only allow us to write to the first block.
We instead make use of `diskpart`'s `clean` command, which bypasses this
Windows limitation by requesting an exclusive lock on the drive
(something we can't do without interacting with the Windows API
 directly), and knows how to clean both MBR and GPT drives.

See: https://github.com/resin-io/etcher/issues/334
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>