### PR TITLE
Make sure the drive is rescaned without a file-system in Windows

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -28,7 +28,7 @@ if (isWindows) {
 var runDiskpartScript = function(script) {
   return Promise.try(function() {
     if (isWindows) {
-      return diskpart.evaluateAsync(script);
+      return diskpart.evaluateAsync(script).delay(2000);
     }
   });
 };
@@ -58,7 +58,8 @@ exports.prepare = function(device) {
     if (deviceId) {
       return runDiskpartScript([
         'select disk ' + deviceId,
-        'clean'
+        'clean',
+        'rescan'
       ]);
     }
   });


### PR DESCRIPTION
Since the following PR: https://github.com/resin-io-modules/etcher-image-write/pull/43, we've
been relying on `diskpart` to clean a device's file system in order for
Windows to allows us to perform direct I/O to physical drives.

This addition seems to have presented a subtle regression, manifesting
again as an `EPERM` error caused by the `write` system call.

After some investigation, the fix is to call the `rescan` command to
make sure the operating system is acknowledged of the cleanup. Also, we
add some delay after running `diskpart` scripts, to give the OS some
time, which seems to be needed for Windows 10 in particular.

See: https://github.com/resin-io/etcher/issues/531
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>