### PR TITLE
Fix diskpart clean command failed error

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -17,6 +17,7 @@
 'use strict';
 
 var Promise = require('bluebird');
+var retry = require('bluebird-retry');
 var os = require('os');
 var _ = require('lodash');
 var isWindows = os.platform() === 'win32';
@@ -56,11 +57,15 @@ exports.prepare = function(device) {
     var deviceId = _.nth(device.match(/PHYSICALDRIVE(\d+)/i), 1);
 
     if (deviceId) {
-      return runDiskpartScript([
-        'select disk ' + deviceId,
-        'clean',
-        'rescan'
-      ]);
+      return retry(function() {
+        return runDiskpartScript([
+          'select disk ' + deviceId,
+          'clean',
+          'rescan'
+        ]);
+      }, {
+        max_tries: 5
+      });
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.5",
+    "bluebird-retry": "^0.7.0",
     "crc32-stream": "^0.4.0",
     "denymount": "^2.1.0",
     "dev-null-stream": "0.0.1",


### PR DESCRIPTION
For some reason, `diskpart clean` seems to randomly fail in some systems
without any explanation, apart from the following entry in the Event Log:

```
Cannot zero sectors on disk \\?\PhysicalDriveN. Error code: 5@0101000F
```

After some experimentation, the issue is gone when simply retrying the `clean`
command.

See: http://www.jc-tech.info/2016/05/26/run-diskpart-clean-twice/
See: https://github.com/resin-io/etcher/issues/571
See: https://github.com/resin-io/etcher/issues/552
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>