### PR TITLE
Throw a human-readable error if the drive runs out of space

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -22,6 +22,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
+var through2 = require('through2');
 var _ = require('lodash');
 var Promise = require('bluebird');
 var progressStream = require('progress-stream');
@@ -35,6 +36,25 @@ var utils = require('./utils');
 var win32 = require('./win32');
 
 var CHUNK_SIZE = 65536 * 16; // 64K * 16 = 1024K = 1M
+
+var safePipe = function(streams, callback) {
+  var current = null;
+
+  _.each(streams, function(stream) {
+    if (!current) {
+      current = stream.stream;
+      return;
+    }
+
+    stream.stream.on('error', callback);
+
+    _.each(stream.events || {}, function(handler, event) {
+      stream.stream.on(event, handler);
+    });
+
+    current = current.pipe(stream.stream);
+  });
+};
 
 /**
  * @summary Write a readable stream to a device
@@ -83,20 +103,26 @@ var CHUNK_SIZE = 65536 * 16; // 64K * 16 = 1024K = 1M
  * compressed stream to `.write()`, pass the *compressed stream size*,
  * and a transform stream to decompress the file.
  *
- * @param {String} device - device
- * @param {ReadStream} stream - readable stream
+ * @param {Object} drive - drive
+ * @param {String} drive.device - drive device
+ * @param {Number} drive.size - drive size
+ * @param {Object} image - image
+ * @param {ReadStream} image.stream - image readable stream
+ * @param {Number} image.size - image stream size
  * @param {Object} options - options
- * @param {Number} options.size - input stream size
  * @param {TransformStream} [options.transform] - transform stream
  * @param {Boolean} [options.check=false] - enable write check
  * @returns {EventEmitter} emitter
  *
  * @example
- * var myStream = fs.createReadStream('my/image');
- *
- * var emitter = imageWrite.write('/dev/disk2', myStream, {
- *   check: true,
+ * var emitter = imageWrite.write({
+ *   device: '/dev/disk2',
+ *   size: 2014314496
+ * }, {
+ *   stream: fs.createWriteStream('my/image'),
  *   size: fs.statSync('my/image').size
+ * }, {
+ *   check: true
  * });
  *
  * emitter.on('progress', function(state) {
@@ -115,54 +141,89 @@ var CHUNK_SIZE = 65536 * 16; // 64K * 16 = 1024K = 1M
  *   }
  * });
  */
-exports.write = function(device, stream, options) {
+exports.write = function(drive, image, options) {
   options = options || {};
 
   var emitter = new EventEmitter();
 
-  if (!options.size) {
-    throw new Error('Missing size option');
+  if (!image.size || !_.isNumber(image.size)) {
+    throw new Error('Invalid image size: ' + image.size);
   }
 
-  device = utils.getRawDevice(device);
+  if (!drive.size || !_.isNumber(drive.size)) {
+    throw new Error('Invalid drive size: ' + drive.size);
+  }
+
+  var devicePath = utils.getRawDevice(drive.device);
 
   // Prevent disks from auto-mounting, since some OSes, like
   // Windows and OS X, "touch" files in FAT partitions,
   // causing our checksum comparison to fail.
-  denymount(device, function(callback) {
+  denymount(devicePath, function(callback) {
 
-    return win32.prepare(device).then(function() {
+    return win32.prepare(devicePath).then(function() {
       return new Promise(function(resolve, reject) {
         var checksumStream = new CRC32Stream();
+        var transferredBytes = 0;
 
-        stream
-          .pipe(progressStream({
-            length: _.parseInt(options.size),
-            time: 500
-          }))
-          .on('progress', function(state) {
-            state.type = 'write';
-            emitter.emit('progress', state);
-          })
-          .pipe(options.transform || new PassThroughStream())
-          .pipe(checksumStream)
-          .pipe(streamChunker(CHUNK_SIZE, {
-            flush: true,
-            align: true
-          }))
-          .pipe(fs.createWriteStream(device, {
-            flags: 'rs+'
-          }))
-          .on('error', function(error) {
-            error.type = 'write';
-            return reject(error);
-          })
-          .on('close', function() {
-            return resolve({
-              checksum: checksumStream.hex().toLowerCase(),
-              size: checksumStream.size()
-            });
-          });
+        return safePipe([
+          {
+            stream: image.stream
+          },
+          {
+            stream: progressStream({
+              length: _.parseInt(image.size),
+              time: 500
+            }),
+            events: {
+              progress: function(state) {
+                state.type = 'write';
+                emitter.emit('progress', state);
+              }
+            }
+          },
+          {
+            stream: options.transform || new PassThroughStream()
+          },
+          {
+            stream: checksumStream
+          },
+          {
+            stream: streamChunker(CHUNK_SIZE, {
+              flush: true,
+              align: true
+            })
+          },
+          {
+            stream: through2(function(chunk, encoding, callback) {
+              transferredBytes += chunk.length;
+
+              if (transferredBytes + CHUNK_SIZE > drive.size) {
+                var error = new Error('Not enough space on the drive');
+                error.code = 'ENOSPC';
+                return callback(error);
+              }
+
+              return callback(null, chunk);
+            })
+          },
+          {
+            stream: fs.createWriteStream(devicePath, {
+              flags: 'rs+'
+            }),
+            events: {
+              close: function() {
+                return resolve({
+                  checksum: checksumStream.hex().toLowerCase(),
+                  size: checksumStream.size()
+                });
+              }
+            }
+          }
+        ], function(error) {
+          error.type = 'write';
+          return reject(error);
+        });
       });
     }).then(function(results) {
       if (!options.check) {
@@ -177,35 +238,49 @@ exports.write = function(device, stream, options) {
       return new Promise(function(resolve, reject) {
         var checksumStream = new CRC32Stream();
 
-        fs.createReadStream(device)
+        return safePipe([
+          {
+            stream: fs.createReadStream(devicePath)
+          },
+          {
 
-          // Only calculate the checksum from the bytes that correspond
-          // to the original image size and not the whole drive since
-          // the drive might contain empty space that changes the
-          // resulting checksum.
-          // See https://help.ubuntu.com/community/HowToMD5SUM#Check_the_CD
-          .pipe(sliceStream({
-            bytes: results.size
-          }))
+            // Only calculate the checksum from the bytes that correspond
+            // to the original image size and not the whole drive since
+            // the drive might contain empty space that changes the
+            // resulting checksum.
+            // See https://help.ubuntu.com/community/HowToMD5SUM#Check_the_CD
+            stream: sliceStream({
+              bytes: results.size
+            })
 
-          .pipe(progressStream({
-            length: _.parseInt(results.size),
-            time: 500
-          }))
-          .on('progress', function(state) {
-            state.type = 'check';
-            emitter.emit('progress', state);
-          })
-          .pipe(checksumStream)
-          .pipe(new DevNullStream())
-          .on('error', function(error) {
-            error.type = 'check';
-            return reject(error);
-          })
-          .on('finish', function() {
-            return resolve(checksumStream.hex().toLowerCase());
-          });
-
+          },
+          {
+            stream: progressStream({
+              length: _.parseInt(results.size),
+              time: 500
+            }),
+            events: {
+              progress: function(state) {
+                state.type = 'check';
+                emitter.emit('progress', state);
+              }
+            }
+          },
+          {
+            stream: checksumStream
+          },
+          {
+            stream: new DevNullStream(),
+            events: {
+              finish: function() {
+                return resolve(checksumStream.hex().toLowerCase());
+              }
+            }
+          }
+        ], function(error) {
+          error.type = 'check';
+          return reject(error);
+        });
       }).tap(win32.rescan).then(function(deviceChecksum) {
         emitter.emit('done', {
           passedValidation: results.checksum === deviceChecksum,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "drivelist": "^3.2.2",
     "jsdoc-to-markdown": "^1.1.1",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.1.0",
@@ -53,6 +54,7 @@
     "lodash": "^4.13.1",
     "progress-stream": "^1.1.1",
     "slice-stream2": "^2.0.0",
-    "stream-chunker": "^1.2.8"
+    "stream-chunker": "^1.2.8",
+    "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
If we try to write a too large image to a drive, an `EIO` error will be
eventually emitted. This error is very generic, and its hard to know if
it was caused by the drive running out of space, or any other I/O error.

As a way to improve the user experience, this PR makes
`etcher-image-write` throws a nice readable `ENOSPC` error instead.

In order to implement this functionality, breaking changes were
introduced. In summary:

- The `.write()` function now takes a required drive size number which
  we use for comparison purposes. We could calculate this in the module
  itself, however for testing purposes (and to avoid duplicating and
  having to maintain logic to do this), we require the user to pass it
  manually.

- The `.write()` function takes a drive *object* and an image *object*,
  in order to clean up a bit the interface now that we're demanding even
  more things.

- The `example.js` was updated to make use of the new interface, and
  check the drive size using the `drivelist` module.

- We introduce a transform stream right before the drive's writable
  stream in which we check that the current transferred amount of bytes
  plus the chunk size we determine in this module is not greater than
  the drive size. If this condition doesn't hold, an `ENOSPC` is
  thrown. This method is very reliably since we chunk the stream into
  predictable sizes (we pad with null bytes otherwise).

- We check for the existence and validity (that it is a number) of the
  `size` options for both the image and the drive.

- We introduce a small private function called `safePipe`, which adds
  `error` handlers to all streams along a pipe to make sure we catch
  every error (otherwise the `ENOSPC` error we throw in the transform
  stream described earlier doesn't get caught) without having to
  manually attach the error handlers over and over again.

See: https://github.com/resin-io/etcher/issues/571
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>