### PR TITLE
Close the device file descriptor after the validation phase

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -237,10 +237,11 @@ exports.write = function(drive, image, options) {
 
       return new Promise(function(resolve, reject) {
         var checksumStream = new CRC32Stream();
+        var deviceStream = fs.createReadStream(devicePath);
 
         return safePipe([
           {
-            stream: fs.createReadStream(devicePath)
+            stream: deviceStream
           },
           {
 
@@ -273,7 +274,16 @@ exports.write = function(drive, image, options) {
             stream: new DevNullStream(),
             events: {
               finish: function() {
-                return resolve(checksumStream.hex().toLowerCase());
+
+                // Make sure the device stream file descriptor is closed
+                // before returning control the the caller. Not closing
+                // the file descriptor (and waiting for it) results in
+                // `EBUSY` errors when attempting to unmount the drive
+                // right afterwards in some Windows 7 systems.
+                deviceStream.close(function() {
+                  return resolve(checksumStream.hex().toLowerCase());
+                });
+
               }
             }
           }


### PR DESCRIPTION
Not doing so causes `EBUSY` when attempting to unmount the drive right
afterwards in some Windows 7 systems.

See: https://github.com/resin-io/etcher/issues/573
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>