### PR TITLE
Upgrade bmapflash to v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "bluebird-retry": "^0.7.0",
-    "bmapflash": "^1.1.1",
+    "bmapflash": "^1.1.2",
     "crc32-stream": "^0.4.0",
     "denymount": "^2.1.0",
     "dev-null-stream": "0.0.1",


### PR DESCRIPTION
This version contains a fix where certain bmap ranges were not being
properly written.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>