### PR TITLE
Don't throw ENOSPC if the drive capacity is equal to the image size

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -134,7 +134,7 @@ exports.usingStreaming = (deviceFileDescriptor, options = {}) => {
         stream: through2(function(chunk, encoding, callback) {
           transferredBytes += chunk.length;
 
-          if (transferredBytes + options.chunkSize > options.driveSize) {
+          if (transferredBytes > options.driveSize) {
             var error = new Error('Not enough space on the drive');
             error.code = 'ENOSPC';
             return callback(error);

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -211,6 +211,29 @@ wary.it('write: should be rejected if the drive is not large enough', {
   });
 });
 
+wary.it('write: should not be rejected if the drive has the same capacity as the image size', {
+  random1: RANDOM1,
+  random2: RANDOM2
+}, function(images) {
+  return new Promise(function(resolve, reject) {
+    var imageSize = fs.statSync(images.random1).size;
+
+    var writer = imageWrite.write({
+      fd: fs.openSync(images.random2, 'rs+'),
+      device: images.random2,
+      size: imageSize
+    }, {
+      stream: fs.createReadStream(images.random1),
+      size: imageSize
+    });
+
+    writer.on('error', reject);
+    writer.on('done', resolve);
+  }).catch(function(error) {
+    m.chai.expect(error).to.not.exist;
+  });
+});
+
 wary.it('check: should eventually be true on success', {
   random1: RANDOM1,
   random2: RANDOM2


### PR DESCRIPTION
The code that checks whether we're about to run out of space has an off
by one issue.

The function collects the length of the chunks the transform stream
received as `transferredBytes`. Once the variable has been incremented,
it checks for

```
transferredBytes + options.chunkSize > options.driveSize
```

But it makes no sense to add the chunk size to `transferredBytes` since
we just incremented it before, causing the variable to be incremented
twice, and give false alarms when the image size is very close to the
capacity of the drive.

See: https://github.com/resin-io/etcher/issues/629
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>