### PR TITLE
Stop passing `passedValidation` and throw an error instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,18 @@ emitter.on('error', function(error) {
 });
 
 emitter.on('done', function(results) {
-  if (results.passedValidation) {
-    console.log('Success!');
-  } else {
-    console.log('Failed!');
-  }
+  console.log('Success!');
 });
 ```
+
+Errors
+------
+
+The errors we emit can be identified by their `code` or `type` properties.
+
+Consult [this
+file](https://github.com/resin-io-modules/etcher-image-write/blob/master/lib/errors.js)
+for a list of defined types.
 
 Support
 -------

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -27,6 +27,15 @@ Documentation
 {{>members~}}
 {{/module}}
 
+Errors
+------
+
+The errors we emit can be identified by their `code` or `type` properties.
+
+Consult [this
+file](https://github.com/resin-io-modules/etcher-image-write/blob/master/lib/errors.js)
+for a list of defined types.
+
 Support
 -------
 

--- a/example.js
+++ b/example.js
@@ -61,12 +61,6 @@ drivelist.list(function(error, drives) {
       console.log(state);
     })
     .on('done', function(results) {
-      if (results.passedValidation) {
-        console.log('Check passed');
-      } else {
-        console.error('Check failed');
-      }
-
       console.log(results);
     });
 });

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const typedError = require('error/typed');
+
+/**
+ * @summary Validation error
+ * @public
+ * @property
+ */
+exports.ValidationError = typedError({
+  message: 'Validation error',
+  type: 'etcher.validation'
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,11 +109,7 @@ var write = require('./write');
  * });
  *
  * emitter.on('done', function(results) {
- *   if (results.passedValidation) {
- *     console.log('Success!');
- *   } else {
- *     console.log('Failed!');
- *   }
+ *   console.log('Success!');
  * });
  */
 exports.write = function(drive, image, options) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -21,6 +21,7 @@ const fs = Bluebird.promisifyAll(require('fs'));
 const bmapflash = require('bmapflash');
 const _ = require('lodash');
 const checksum = require('./checksum');
+const errors = require('./errors');
 
 /**
  * @summary Validate an image using bmap
@@ -31,7 +32,6 @@ const checksum = require('./checksum');
  * @param {Object} options - options
  * @param {String} options.bmapContents - bmap xml contents
  * @param {Function} options.progress - progress callback (state)
- * @fulfil {Object} - results
  * @returns {Promise}
  *
  * @example
@@ -44,8 +44,8 @@ const checksum = require('./checksum');
  *   progress: (state) => {
  *     console.log(state);
  *   }
- * }).then((results) => {
- *   console.log(results.passedValidation);
+ * }).then(() => {
+ *   console.log('Done!');
  * });
  */
 exports.usingBmap = (deviceFileDescriptor, options = {}) => {
@@ -55,9 +55,11 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
     validator.on('error', reject);
     validator.on('done', resolve);
   }).then((invalidRanges) => {
-    return {
-      passedValidation: _.isEmpty(invalidRanges)
-    };
+    if (!_.isEmpty(invalidRanges)) {
+      throw errors.ValidationError;
+    }
+
+    return {};
   });
 };
 
@@ -83,7 +85,7 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
  *     console.log(state);
  *   }
  * }).then((results) => {
- *   console.log(results.passedValidation);
+ *   console.log(results.sourceChecksum);
  * });
  */
 exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
@@ -91,8 +93,11 @@ exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
     imageSize: options.imageSize,
     progress: options.progress
   }).then((deviceChecksum) => {
+    if (options.imageChecksum !== deviceChecksum) {
+      throw errors.ValidationError;
+    }
+
     return {
-      passedValidation: options.imageChecksum === deviceChecksum,
       sourceChecksum: options.imageChecksum
     };
   });
@@ -118,13 +123,12 @@ exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
  * validate.mock(fd, {
  *   imageChecksum: '717a34c1',
  * }).then((results) => {
- *   console.log(results.passedValidation);
+ *   console.log(results.sourceChecksum);
  * });
  */
 exports.mock = (deviceFileDescriptor, options = {}) => {
   return fs.closeAsync(deviceFileDescriptor).then(() => {
     return {
-      passedValidation: true,
       sourceChecksum: options.imageChecksum
     };
   });
@@ -147,7 +151,7 @@ exports.mock = (deviceFileDescriptor, options = {}) => {
  * @example
  * const fd = fs.openSync('/dev/rdisk2', 'rs+');
  * validate.inferFromOptions(fd, { ... }).then((results) => {
- *   console.log(results.passedValidation);
+ *   console.log(results);
  * });
  */
 exports.inferFromOptions = (deviceFileDescriptor, options = {}) => {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "crc32-stream": "^0.4.0",
     "dev-null-stream": "0.0.1",
     "drivelist": "^3.3.0",
+    "error": "^7.0.2",
     "lodash": "^4.13.1",
     "progress-stream": "^1.1.1",
     "slice-stream2": "^2.0.0",

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -50,7 +50,6 @@ wary.it('write: should be able to burn data to a file', {
     writer.on('error', reject);
     writer.on('done', resolve);
   }).then(function(results) {
-    m.chai.expect(results.passedValidation).to.be.true;
     m.chai.expect(results.sourceChecksum).to.equal('2f73fef');
 
     return Promise.props({
@@ -86,7 +85,6 @@ wary.it('write: should be able to burn a bmap image to a file', {
     writer.on('error', reject);
     writer.on('done', resolve);
   }).then(function(results) {
-    m.chai.expect(results.passedValidation).to.be.true;
     m.chai.expect(results.sourceChecksum).to.be.undefined;
 
     return Promise.props({
@@ -254,8 +252,6 @@ wary.it('check: should eventually be true on success', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(results) {
-    m.chai.expect(results.passedValidation).to.be.true;
   });
 });
 
@@ -286,10 +282,15 @@ wary.it('check: should eventually be false on failure', {
 
     writer.on('error', reject);
     writer.on('done', resolve);
-  }).then(function(results) {
-    m.chai.expect(results.passedValidation).to.be.false;
-    createReadStreamStub.restore();
-  });
+
+  // Ensure we don't get false positives if the `.catch()`
+  // block is never called because validation passed.
+  }).then(function() {
+    throw new Error('Validation Passed');
+
+  }).catch(function(error) {
+    m.chai.expect(error.type).to.equal('etcher.validation');
+  }).finally(createReadStreamStub.restore);
 });
 
 wary.it('transform: should be able to decompress an gz image', {
@@ -315,8 +316,6 @@ wary.it('transform: should be able to decompress an gz image', {
     writer.on('error', reject);
     writer.on('done', resolve);
   }).then(function(results) {
-    m.chai.expect(results.passedValidation).to.be.true;
-
     return Promise.props({
       real: fs.readFileAsync(images.real),
       output: fs.readFileAsync(images.output)


### PR DESCRIPTION
For convenience, instead of including a boolean property in the final
results object, we throw a "validation error", which is simply amn error
object containing a special `code` property.

This PR is a breaking change.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>