### PR TITLE
Set defined error types to `etcher`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ emitter.on('done', function(results) {
 Errors
 ------
 
-The errors we emit can be identified by their `code` or `type` properties.
+The errors we emit can be identified by their `code` and `type` properties.
 
 Consult [this
 file](https://github.com/resin-io-modules/etcher-image-write/blob/master/lib/errors.js)
-for a list of defined types.
+for a list of defined errors.
 
 Support
 -------

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -30,11 +30,11 @@ Documentation
 Errors
 ------
 
-The errors we emit can be identified by their `code` or `type` properties.
+The errors we emit can be identified by their `code` and `type` properties.
 
 Consult [this
 file](https://github.com/resin-io-modules/etcher-image-write/blob/master/lib/errors.js)
-for a list of defined types.
+for a list of defined errors.
 
 Support
 -------

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -25,5 +25,6 @@ const typedError = require('error/typed');
  */
 exports.ValidationError = typedError({
   message: 'Validation error',
-  type: 'etcher.validation'
+  type: 'etcher',
+  code: 'EVALIDATION'
 });

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -289,7 +289,7 @@ wary.it('check: should eventually be false on failure', {
     throw new Error('Validation Passed');
 
   }).catch(function(error) {
-    m.chai.expect(error.type).to.equal('etcher.validation');
+    m.chai.expect(error.code).to.equal('EVALIDATION');
   }).finally(createReadStreamStub.restore);
 });
 


### PR DESCRIPTION
The actual information about the error was moved to `.code`, for
consistency with other projects that use this module.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>

 of text is the title and the rest is the description.