### PR TITLE
Add `bytesToZeroOutFromTheBeginning` for bmap writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ and a transform stream to decompress the file.
 | [options.transform] | <code>TransformStream</code> |  | transform stream |
 | [options.check] | <code>Boolean</code> | <code>false</code> | enable write check |
 | [options.bmap] | <code>String</code> |  | bmap file contents |
+| [options.bytesToZeroOutFromTheBeginning] | <code>Number</code> |  | bytes to zero out from the beginning (bmap only) |
 
 **Example**  
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,7 @@ var write = require('./write');
  * @param {TransformStream} [options.transform] - transform stream
  * @param {Boolean} [options.check=false] - enable write check
  * @param {String} [options.bmap] - bmap file contents
+ * @param {Number} [options.bytesToZeroOutFromTheBeginning] - bytes to zero out from the beginning (bmap only)
  * @returns {EventEmitter} emitter
  *
  * @example
@@ -131,6 +132,7 @@ exports.write = function(drive, image, options) {
       imageStream: image.stream,
       transformStream: options.transform,
       bmapContents: options.bmap,
+      bytesToZeroOutFromTheBeginning: options.bytesToZeroOutFromTheBeginning,
       chunkSize: 65536 * 16, // 64K * 16 = 1024K = 1M
       driveSize: drive.size,
       progress: (state) => {

--- a/lib/write.js
+++ b/lib/write.js
@@ -36,6 +36,7 @@ const utils = require('./utils');
  * @param {Object} options - options
  * @param {ReadableStream} options.imageStream - image stream
  * @param {String} options.bmapContents - bmap xml contents
+ * @param {Number} [options.bytesToZeroOutFromTheBeginning] - bytes to zero out from the beginning
  * @param {Function} options.progress - progress callback (state)
  * @fulfil {Object} - results
  * @returns {Promise}
@@ -59,7 +60,10 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
     const flasher = bmapflash.flashImageToFileDescriptor(
       options.imageStream,
       deviceFileDescriptor,
-      options.bmapContents
+      options.bmapContents,
+      {
+        bytesToZeroOutFromTheBeginning: options.bytesToZeroOutFromTheBeginning
+      }
     );
 
     flasher.on('progress', options.progress);
@@ -185,6 +189,7 @@ exports.inferFromOptions = (deviceFileDescriptor, options = {}) => {
     return exports.usingBmap(deviceFileDescriptor, {
       imageStream: options.imageStream,
       bmapContents: options.bmapContents,
+      bytesToZeroOutFromTheBeginning: options.bytesToZeroOutFromTheBeginning,
       progress: options.progress
     });
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "bluebird-retry": "^0.7.0",
-    "bmapflash": "^1.1.2",
+    "bmapflash": "^1.2.0",
     "crc32-stream": "^0.4.0",
     "dev-null-stream": "0.0.1",
     "drivelist": "^3.3.0",


### PR DESCRIPTION
This option, introduced in `bmapflash@1.2.0`, allows the client to
specify a number of bytes that should be zeroed out from the head of the
drive before starting the actual bmap-assisted writing.

See: https://github.com/resin-io-modules/bmapflash/pull/6
See: https://github.com/resin-io/etcher/issues/673
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>