### PR TITLE
Validate contents using the actual transferred bytes information

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ exports.write = function(drive, image, options) {
     return validate.inferFromOptions(drive.fd, {
       omitValidation: !options.check,
       bmapContents: options.bmap,
-      imageSize: image.size,
+      imageSize: options.transferredBytes,
       imageChecksum: results.checksum,
       progress: (state) => {
         state.type = 'check';

--- a/lib/write.js
+++ b/lib/write.js
@@ -34,6 +34,7 @@ const utils = require('./utils');
  *
  * @param {Number} deviceFileDescriptor - device file descriptor
  * @param {Object} options - options
+ * @param {Number} options.imageSize - image size
  * @param {ReadableStream} options.imageStream - image stream
  * @param {String} options.bmapContents - bmap xml contents
  * @param {Number} [options.bytesToZeroOutFromTheBeginning] - bytes to zero out from the beginning
@@ -45,6 +46,7 @@ const utils = require('./utils');
  * const fd = fs.openSync('/dev/rdisk2', 'rs+');
  * write.usingBmap(fd, {
  *   imageStream: fs.createReadStream('path/to/image'),
+ *   imageSize: 65536 * 128,
  *   bmapContents: fs.readFileSync('path/to/image.bmap', {
  *     encoding: 'utf8'
  *   }),
@@ -69,7 +71,9 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
     flasher.on('progress', options.progress);
     flasher.on('error', reject);
     flasher.on('done', () => {
-      return resolve({});
+      return resolve({
+        transferredBytes: options.imageSize
+      });
     });
   });
 };
@@ -155,6 +159,7 @@ exports.usingStreaming = (deviceFileDescriptor, options = {}) => {
         events: {
           finish: function() {
             return resolve({
+              transferredBytes: transferredBytes,
               checksum: checksumStream.hex().toLowerCase()
             });
           }
@@ -188,6 +193,7 @@ exports.inferFromOptions = (deviceFileDescriptor, options = {}) => {
   if (options.bmapContents) {
     return exports.usingBmap(deviceFileDescriptor, {
       imageStream: options.imageStream,
+      imageSize: options.imageSize,
       bmapContents: options.bmapContents,
       bytesToZeroOutFromTheBeginning: options.bytesToZeroOutFromTheBeginning,
       progress: options.progress

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -255,6 +255,29 @@ wary.it('check: should eventually be true on success', {
   });
 });
 
+wary.it('check: should eventually be true on success even if the image size is incorrect', {
+  random1: RANDOM1,
+  random2: RANDOM2
+}, function(images) {
+  return new Promise(function(resolve, reject) {
+    var imageSize = fs.statSync(images.random1).size * 0.8;
+
+    var writer = imageWrite.write({
+      fd: fs.openSync(images.random2, 'rs+'),
+      device: images.random2,
+      size: imageSize * 2
+    }, {
+      stream: fs.createReadStream(images.random1),
+      size: imageSize
+    }, {
+      check: true
+    });
+
+    writer.on('error', reject);
+    writer.on('done', resolve);
+  });
+});
+
 wary.it('check: should eventually be false on failure', {
   random1: RANDOM1,
   random2: RANDOM2,


### PR DESCRIPTION
Currently, we slice the flashed drive stream to the image size number in
order to not check more data than we should, however in the case of
compressed images, the passed image size might refer to the "compressed"
image size, causing this module to slice less than it should, and
therefore cause incorrect validation errors.

As a real fix, we keep an eye on how many bytes we actually transferred,
and use that information to correctly slice the drive stream.

See: https://github.com/resin-io/etcher/issues/710
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>