### PR TITLE
Only run Appveyor CI tests in cmd.exe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,4 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - ps: npm test
   - cmd: npm test


### PR DESCRIPTION
We're currently running them in both `cmd.exe` and PowerShell for some
reason.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>