### PR TITLE
HOTFIX: Fix validation progress being stuck

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ exports.write = function(drive, image, options) {
     return validate.inferFromOptions(drive.fd, {
       omitValidation: !options.check,
       bmapContents: options.bmap,
-      imageSize: options.transferredBytes,
+      imageSize: results.transferredBytes,
       imageChecksum: results.checksum,
       progress: (state) => {
         state.type = 'check';


### PR DESCRIPTION
We should be reading the image size from `results`, not from `options`.
This was causing all validations to get stuck given there was no size to
slice with.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>