### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ var emitter = imageWrite.write({
   device: '/dev/rdisk2',
   size: 2014314496
 }, {
-  stream: fs.createWriteStream('my/image'),
+  stream: fs.createReadStream('my/image'),
   size: fs.statSync('my/image').size
 }, {
   check: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ var write = require('./write');
  *   device: '/dev/rdisk2',
  *   size: 2014314496
  * }, {
- *   stream: fs.createWriteStream('my/image'),
+ *   stream: fs.createReadStream('my/image'),
  *   size: fs.statSync('my/image').size
  * }, {
  *   check: true


### PR DESCRIPTION
The image stream should be a readable stream instead of a writable one.

Fixes: https://github.com/resin-io-modules/etcher-image-write/issues/66
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>