### PR TITLE
Prevent unhandled error events from the first stream of `utils.safePipe`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,24 +51,27 @@ const _ = require('lodash');
 exports.safePipe = (streams, callback) => {
   let current = null;
 
+  // Make sure all event handlers are
+  // attached before piping the streams.
   _.each(streams, (stream) => {
-    if (!current) {
-      current = stream.stream;
-      return;
-    }
-
     stream.stream.on('error', callback);
 
     _.each(stream.events || {}, (handler, event) => {
       stream.stream.on(event, handler);
     });
-
-    current = current.pipe(stream.stream);
   });
 
   _.last(streams).stream
     .on('done', callback)
     .on('finish', callback);
+
+  _.each(streams, (stream) => {
+    if (current) {
+      current = current.pipe(stream.stream);
+    } else {
+      current = stream.stream;
+    }
+  });
 };
 
 /**

--- a/tests/mock-stream.js
+++ b/tests/mock-stream.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const stream = require('stream');
+const _ = require('lodash');
+
+/**
+ * @summary Create a mock read stream
+ * @class
+ * @public
+ */
+exports.Readable = class MockReadStream extends stream.Readable {
+
+  /**
+   * @summary Create a mock read stream
+   * @public
+   *
+   * @param {Array} data - data
+   *
+   * @example
+   * const stream = new mockStream.Readable([ 1, 2, 3 ]);
+   */
+  constructor(data) {
+    super({
+      objectMode: true,
+      read: () => {
+        _.each(data, (item) => {
+          this.push(item);
+        });
+
+        this.push(null);
+      }
+    });
+  }
+
+};
+
+/**
+ * @summary Create a collector mock writable stream
+ * @class
+ * @public
+ */
+exports.Writable = class CollectorWriteStream extends stream.Writable {
+
+  /**
+   * @summary Create a collector mock writable stream
+   * @public
+   *
+   * @example
+   * const stream = new mockStream.Writable();
+   *
+   * stream.on('finish', () => {
+   *   console.log(stream.data);
+   * });
+   */
+  constructor() {
+    super({
+      objectMode: true,
+      write: (chunk, encoding, callback) => {
+        this.data = this.data || [];
+        this.data.push(chunk);
+        return callback();
+      }
+    });
+  }
+
+};


### PR DESCRIPTION
We have a utility function called `utils.safePipe()` that accepts an
array of streams and pipes them all together attaching error handlers at
every step.

We didn't recognise a subtle flaw that would prevent the error handler
(and any event listener, really) to be attached to the first stream on
the pipe chain: we check if `current` exists, and if not, set the
current stream as `current` however we `return` right away, which means
the error handler and event handlers defined just below never get called
on the first stream (which is the only case where `current` is not
defined).

As a bonus, this commit adds some unit tests for `utils.safePipe()`.

See: https://github.com/resin-io/etcher/issues/981
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>