### PR TITLE
Make utils.safePipe adhere to NodeJS callback convention

### DIFF
--- a/lib/checksum.js
+++ b/lib/checksum.js
@@ -92,23 +92,23 @@ exports.calculateDeviceChecksum = (deviceFileDescriptor, options = {}) => {
         // The checksum stream needs to be piped somewhere
         // so data starts going through it and it actually
         // starts calculating the checksum.
-        stream: new DevNullStream(),
+        stream: new DevNullStream()
 
-        events: {
-          finish: () => {
-
-            // Make sure the device stream file descriptor is closed
-            // before returning control the the caller. Not closing
-            // the file descriptor (and waiting for it) results in
-            // `EBUSY` errors when attempting to unmount the drive
-            // right afterwards in some Windows 7 systems.
-            deviceStream.close(() => {
-              return resolve(checksumStream.hex().toLowerCase());
-            });
-
-          }
-        }
       }
-    ], reject);
+    ], (error) => {
+      if (error) {
+        return reject(error);
+      }
+
+      // Make sure the device stream file descriptor is closed
+      // before returning control the the caller. Not closing
+      // the file descriptor (and waiting for it) results in
+      // `EBUSY` errors when attempting to unmount the drive
+      // right afterwards in some Windows 7 systems.
+      deviceStream.close(() => {
+        return resolve(checksumStream.hex().toLowerCase());
+      });
+
+    });
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,6 +65,10 @@ exports.safePipe = (streams, callback) => {
 
     current = current.pipe(stream.stream);
   });
+
+  _.last(streams).stream
+    .on('done', callback)
+    .on('finish', callback);
 };
 
 /**

--- a/lib/write.js
+++ b/lib/write.js
@@ -168,17 +168,18 @@ exports.usingStreaming = (deviceFileDescriptor, options = {}) => {
         })
       },
       {
-        stream: new ImageWriteStream(deviceFileDescriptor),
-        events: {
-          done: () => {
-            return resolve({
-              transferredBytes: transferredBytes,
-              checksum: checksumStream.hex().toLowerCase()
-            });
-          }
-        }
+        stream: new ImageWriteStream(deviceFileDescriptor)
       }
-    ], reject);
+    ], (error) => {
+      if (error) {
+        return reject(error);
+      }
+
+      return resolve({
+        transferredBytes: transferredBytes,
+        checksum: checksumStream.hex().toLowerCase()
+      });
+    });
   });
 };
 


### PR DESCRIPTION
Currently, `utils.safePipe()` accepts a callback that is only called
when an error happens, leaving the responsibility to attach an event
listener to the last stream to the user.

Now, `utils.safePipe()` attaches prefedefined event listeners to the
last stream (`finish`, and `done`), and calls the callback when they are
emitted.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>