### PR TITLE
Improve error handling on premature device disconnect

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -322,7 +322,7 @@ rules:
   no-array-constructor:
     - error
   no-bitwise:
-    - error
+    - off
   no-continue:
     - error
   no-inline-comments:

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -19,6 +19,7 @@
 const Promise = require('bluebird');
 const retry = require('bluebird-retry');
 const os = require('os');
+const fs = require('fs');
 const _ = require('lodash');
 
 const runDiskpartScript = (script) => {
@@ -53,6 +54,11 @@ exports.prepare = (device) => {
     const deviceId = _.nth(device.match(/PHYSICALDRIVE(\d+)/i), 1);
 
     if (deviceId) {
+
+      // Test whether the device is accessible,
+      // and if not – throw – rejecting the promise
+      fs.accessSync(device, fs.constants.R_OK | fs.constants.W_OK);
+
       return retry(() => {
         return runDiskpartScript([
           'select disk ' + deviceId,
@@ -60,13 +66,10 @@ exports.prepare = (device) => {
           'rescan'
         ]);
       }, {
-
         /* eslint-disable camelcase */
-
         max_tries: 5
 
         /* eslint-enable camelcase */
-
       });
     }
   });


### PR DESCRIPTION
**Connects to:**
- https://github.com/resin-io/etcher/issues/1124
- https://github.com/resin-io/etcher/issues/1127

**Changes:**
- Disabled the `no-bitwise` eslint rule, as bitmasks couldn't be used otherwise
- Added an access check before attempting to run `diskpart`

**To do:**
- [ ] Add and document common error codes for these errors (`ENXIO`, `ENOENT`, `EIO`, ...)
- [ ] Manually test this for proper behavior on Windows