### PR TITLE
Disable trimming whitespace in Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{md,mkd,markdown}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prevent the editorconfig from nuking newlines in the README's docs.