### PR TITLE
Add Versionist & npm version scripts for automatic versioning

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,13 @@
-tests
+# Files
+.*
+*.md
+*.log
+
+# Directories
 doc
+tests
+example
+benchmark
+
+# Versionist configuration
+versionist.conf.js

--- a/doc/CHANGELOG.hbs
+++ b/doc/CHANGELOG.hbs
@@ -1,0 +1,26 @@
+
+## v{{version}} - {{moment date "Y-MM-DD"}}
+{{#if features.length}}
+
+### Features
+
+{{#each features}}
+- {{#if subject.scope}}**{{subject.scope}}:** {{/if}}{{subject.title}}
+{{/each}}
+{{/if}}
+{{#if fixes.length}}
+
+### Fixes
+
+{{#each fixes}}
+- {{#if subject.scope}}**{{subject.scope}}:** {{/if}}{{subject.title}}
+{{/each}}
+{{/if}}
+{{#if misc.length}}
+
+### Misc
+
+{{#each misc}}
+- {{#if subject.scope}}**{{subject.scope}}:** {{/if}}{{subject.title}}
+{{/each}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "test": "npm run lint && mocha --recursive tests/*.spec.js -R spec && node tests/e2e.js",
     "lint": "eslint lib tests bin example.js",
-    "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md"
+    "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
+    "postversion": "versionist"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
@@ -34,6 +35,7 @@
     "jsdoc-to-markdown": "^2.0.1",
     "mocha": "^3.2.0",
     "mochainon": "^1.0.0",
+    "versionist": "^2.8.1",
     "wary": "^1.1.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint lib tests bin example.js",
     "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
     "bump": "npm version --tag-version-prefix \"\" -m \"v%s\"",
-    "version": "versionist"
+    "version": "npm run changelog",
+    "changelog": "versionist"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint lib tests bin example.js",
     "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
     "bump": "npm version --tag-version-prefix \"\" -m \"v%s\"",
-    "postversion": "versionist"
+    "version": "versionist"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "npm run lint && mocha --recursive tests/*.spec.js -R spec && node tests/e2e.js",
     "lint": "eslint lib tests bin example.js",
     "readme": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
+    "bump": "npm version --tag-version-prefix \"\" -m \"v%s\"",
     "postversion": "versionist"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,19 +1,24 @@
 'use strict';
 
+var fs = require('fs');
+
 module.exports = {
   subjectParser: 'angular',
   editChangelog: true,
   editVersion: false,
+  template: fs.readFileSync( __dirname + '/doc/CHANGELOG.hbs', 'utf8' ),
   addEntryToChangelog: {
     preset: 'prepend',
     fromLine: 5
   },
   getIncrementLevelFromCommit: (commit) => {
-    if( /(feat)/i.test( commit.subject.type ) )
-      return 'minor'
+    if( commit.subject.type == 'feat' )
+      return 'minor';
     return 'patch';
   },
   transformTemplateData: (data) => {
+
+    console.log( data )
 
     data.features = data.commits.filter((commit) => {
       return commit.subject.type === 'feat';

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -8,7 +8,13 @@ module.exports = {
     preset: 'prepend',
     fromLine: 5
   },
+  getIncrementLevelFromCommit: (commit) => {
+    if( /(feat)/i.test( commit.subject.type ) )
+      return 'minor'
+    return 'patch';
+  },
   transformTemplateData: (data) => {
+
     data.features = data.commits.filter((commit) => {
       return commit.subject.type === 'feat';
     });
@@ -22,5 +28,6 @@ module.exports = {
     });
 
     return data;
+
   },
 }

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  subjectParser: 'angular',
+  editChangelog: true,
+  editVersion: false,
+  addEntryToChangelog: {
+    preset: 'prepend',
+    fromLine: 5
+  },
+  transformTemplateData: (data) => {
+    data.features = data.commits.filter((commit) => {
+      return commit.subject.type === 'feat';
+    });
+
+    data.fixes = data.commits.filter((commit) => {
+      return commit.subject.type === 'fix';
+    });
+
+    data.misc = data.commits.filter((commit) => {
+      return ![ 'fix', 'feat' ].includes(commit.subject.type);
+    });
+
+    return data;
+  },
+}


### PR DESCRIPTION
With this, the following will run `versionist`, update the `CHANGELOG.md`, bump the `package.json` version, commit & tag:
```sh
npm run bump patch
```

Example changelog update diff:
```diff
+## v9.0.1 - 2017-03-01
+
+### Misc
+
+- **versionist:** Add changelog template
+- **versionist:** Add `getIncrementLevelFromCommit()`
+- **package:** Add "bump" script
+- **versionist:** Add versionist.conf.js
+- **package:** Add versionist & postversion hook
+- **editorconfig:** Disable trimming whitespace in Markdown (#89)
+- Update dependencies (#88)
+- Fix ENOSPC / EINVAL caused by chunk padding (#84)
+- **package:** Update dependencies (#82)
+- Update ImageStreamPosition unit tests (#81)
+
```