### PR TITLE
Correctly throw TypedError instances

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -23,7 +23,7 @@ const typedError = require('error/typed');
  * @public
  * @property
  */
-exports.ValidationError = typedError({
+exports.validationError = typedError({
   message: 'Validation error',
   type: 'etcher',
   code: 'EVALIDATION'

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -55,7 +55,7 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
     validator.on('done', resolve);
   }).then((invalidRanges) => {
     if (!_.isEmpty(invalidRanges)) {
-      throw errors.ValidationError;
+      throw errors.validationError();
     }
 
     return {};
@@ -96,7 +96,7 @@ exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
     chunkSize: options.chunkSize
   }).then((deviceChecksum) => {
     if (options.imageChecksum !== deviceChecksum) {
-      throw errors.ValidationError;
+      throw errors.validationError();
     }
 
     return {

--- a/tests/evalidation/test.js
+++ b/tests/evalidation/test.js
@@ -60,6 +60,7 @@ module.exports = [
       }).then(() => {
         throw new Error('Validation Passed');
       }).catch((error) => {
+        m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.code).to.equal('EVALIDATION');
       }).finally(() => {
         calculateDeviceChecksumStub.restore();


### PR DESCRIPTION
This module declares `error.ValidationError`, which is an instance of
`TypedError`. We used it like this:

```js
throw errors.ValidationError;
```

The resulting thrown error is not an error instance, but still has some
of the properties we declare, like the code, therefore confusing the
tests.

This eventually caused problems in Etcher when trying to stringify the
error using the robot module.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>