### PR TITLE
Add support for node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ script:
   - xvfb-run --server-args=$XVFB_ARGS npm test
 node_js:
   - "6"
+  - "4"
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ cache:
 environment:
   matrix:
     - nodejs_version: 6
+    - nodejs_version: 4
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/lib/checksum.js
+++ b/lib/checksum.js
@@ -49,7 +49,7 @@ const utils = require('./utils');
  *   console.log(deviceChecksum);
  * });
  */
-exports.calculateDeviceChecksum = (deviceFileDescriptor, options = {}) => {
+exports.calculateDeviceChecksum = (deviceFileDescriptor, options) => {
   const checksumStream = new CRC32Stream();
 
   return new Bluebird((resolve, reject) => {

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -62,7 +62,9 @@ const RETRY_BASE_TIMEOUT = 100;
  *   console.log('We wrote a 65536 bytes chunk at position 0');
  * });
  */
-exports.writeChunk = (fd, chunk, position, callback, retries = 1) => {
+exports.writeChunk = (fd, chunk, position, callback, retries) => {
+  retries = retries || 1;
+
   fs.write(fd, chunk, 0, chunk.length, position, (error, bytesWritten) => {
     if (error) {
 
@@ -114,7 +116,9 @@ exports.writeChunk = (fd, chunk, position, callback, retries = 1) => {
  *   console.log(buffer);
  * });
  */
-exports.readChunk = (fd, size, position, callback, retries = 1) => {
+exports.readChunk = (fd, size, position, callback, retries) => {
+  retries = retries || 1;
+
   fs.read(fd, Buffer.allocUnsafe(size), 0, size, position, (error, bytesRead, buffer) => {
 
     if (error) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -47,7 +47,7 @@ const errors = require('./errors');
  *   console.log('Done!');
  * });
  */
-exports.usingBmap = (deviceFileDescriptor, options = {}) => {
+exports.usingBmap = (deviceFileDescriptor, options) => {
   return new Bluebird((resolve, reject) => {
     const validator = bmapflash.validateFlashedImage(deviceFileDescriptor, options.bmapContents);
     validator.on('progress', options.progress);
@@ -89,7 +89,7 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
  *   console.log(results.sourceChecksum);
  * });
  */
-exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
+exports.usingChecksum = (deviceFileDescriptor, options) => {
   return checksum.calculateDeviceChecksum(deviceFileDescriptor, {
     imageSize: options.imageSize,
     progress: options.progress,
@@ -128,7 +128,7 @@ exports.usingChecksum = (deviceFileDescriptor, options = {}) => {
  *   console.log(results.sourceChecksum);
  * });
  */
-exports.mock = (deviceFileDescriptor, options = {}) => {
+exports.mock = (deviceFileDescriptor, options) => {
   return Bluebird.resolve({
     sourceChecksum: options.imageChecksum
   });
@@ -154,7 +154,7 @@ exports.mock = (deviceFileDescriptor, options = {}) => {
  *   console.log(results);
  * });
  */
-exports.inferFromOptions = (deviceFileDescriptor, options = {}) => {
+exports.inferFromOptions = (deviceFileDescriptor, options) => {
   if (options.omitValidation) {
     return exports.mock(deviceFileDescriptor, {
       imageChecksum: options.imageChecksum

--- a/lib/write.js
+++ b/lib/write.js
@@ -57,7 +57,7 @@ const utils = require('./utils');
  *   console.log('Done!');
  * });
  */
-exports.usingBmap = (deviceFileDescriptor, options = {}) => {
+exports.usingBmap = (deviceFileDescriptor, options) => {
   return new Bluebird((resolve, reject) => {
     const flasher = bmapflash.flashImageToFileDescriptor(
       options.imageStream,
@@ -110,7 +110,7 @@ exports.usingBmap = (deviceFileDescriptor, options = {}) => {
  *   console.log('Done!');
  * });
  */
-exports.usingStreaming = (deviceFileDescriptor, options = {}) => {
+exports.usingStreaming = (deviceFileDescriptor, options) => {
   return new Bluebird((resolve, reject) => {
     const checksumStream = new CRC32Stream();
     let transferredBytes = 0;
@@ -196,7 +196,7 @@ exports.usingStreaming = (deviceFileDescriptor, options = {}) => {
  *   console.log('Done!');
  * });
  */
-exports.inferFromOptions = (deviceFileDescriptor, options = {}) => {
+exports.inferFromOptions = (deviceFileDescriptor, options) => {
   if (options.bmapContents) {
     return exports.usingBmap(deviceFileDescriptor, {
       imageStream: options.imageStream,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "bluebird-retry": "^0.10.1",
-    "bmapflash": "^1.2.0",
+    "bmapflash": "^1.2.1",
     "crc32-stream": "^1.0.1",
     "dev-null-stream": "0.0.1",
     "drivelist": "^5.0.14",


### PR DESCRIPTION
Node.js v4 was unsupported simply because of default arguments, which
were actually useless in most cases in the code base.

This commit also upgrades `bmapflash` to a version that is compatible
with Node.js v4.

See: https://github.com/resin-io-modules/bmapflash/pull/7
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>