### PR TITLE
Throw EUNPLUGGED if the drive gets unplugged during write/validation

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -28,3 +28,14 @@ exports.validationError = typedError({
   type: 'etcher',
   code: 'EVALIDATION'
 });
+
+/**
+ * @summary Unplugged error
+ * @public
+ * @property
+ */
+exports.unpluggedError = typedError({
+  message: 'Drive was unplugged',
+  type: 'etcher',
+  code: 'EUNPLUGGED'
+});

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -17,6 +17,8 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
+const errors = require('./errors');
 
 // The functions to perform common I/O operations defined in this file
 // contains certain workarounds to compensate SDCard errors and similar
@@ -65,11 +67,24 @@ const RETRY_BASE_TIMEOUT = 100;
 exports.writeChunk = (fd, chunk, position, callback, retries = 1) => {
   fs.write(fd, chunk, 0, chunk.length, position, (error, bytesWritten) => {
     if (error) {
+      const platform = os.platform();
+
+      if (error.code === 'ENXIO' && platform === 'darwin') {
+        return callback(errors.unpluggedError());
+      }
+
+      if (error.code === 'ENOENT' && platform === 'win32') {
+        return callback(errors.unpluggedError());
+      }
 
       // In some faulty SDCards or SDCard readers you might randomly
       // get EIO errors, but they usually go away after some retries.
       if (error.code === 'EIO') {
         if (retries > MAXIMUM_RETRIES) {
+          if (platform === 'linux') {
+            return callback(errors.unpluggedError());
+          }
+
           return callback(error);
         }
 
@@ -116,13 +131,25 @@ exports.writeChunk = (fd, chunk, position, callback, retries = 1) => {
  */
 exports.readChunk = (fd, size, position, callback, retries = 1) => {
   fs.read(fd, Buffer.allocUnsafe(size), 0, size, position, (error, bytesRead, buffer) => {
-
     if (error) {
+      const platform = os.platform();
+
+      if (error.code === 'ENXIO' && platform === 'darwin') {
+        return callback(errors.unpluggedError());
+      }
+
+      if (error.code === 'ENOENT' && platform === 'win32') {
+        return callback(errors.unpluggedError());
+      }
 
       // In some faulty SDCards or SDCard readers you might randomly
       // get EIO errors, but they usually go away after some retries.
       if (error.code === 'EIO') {
         if (retries > MAXIMUM_RETRIES) {
+          if (platform === 'linux') {
+            return callback(errors.unpluggedError());
+          }
+
           return callback(error);
         }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jsdoc-to-markdown": "^2.0.1",
     "mocha": "^3.2.0",
     "mochainon": "^1.0.0",
+    "tmp": "0.0.31",
     "versionist": "^2.8.1"
   },
   "optionalDependencies": {

--- a/tests/filesystem.spec.js
+++ b/tests/filesystem.spec.js
@@ -1,0 +1,516 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const fs = require('fs');
+const os = require('os');
+const tmp = require('tmp');
+const filesystem = require('../lib/filesystem');
+
+describe('Filesystem', function() {
+
+  // For some strange reasons, setTimeout gets extremely slow after X
+  // calls on Electron only. This big timeout ensures that all timeouts
+  // have time to complete correctly.
+  this.timeout(40000);
+
+  beforeEach(function() {
+    this.fileDescriptor = tmp.fileSync().fd;
+  });
+
+  afterEach(function() {
+    fs.closeSync(this.fileDescriptor);
+  });
+
+  describe('.writeChunk()', function() {
+
+    describe('given fs.write throws "ENXIO: no such device or address, write"', function() {
+
+      beforeEach(function() {
+        this.fsWriteStub = m.sinon.stub(fs, 'write');
+        const error = new Error('ENXIO: no such device or address, write');
+        error.code = 'ENXIO';
+        this.fsWriteStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsWriteStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENXIO error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENXIO');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENXIO error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENXIO');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('given fs.write throws "ENOENT: no such file or directory, write"', function() {
+
+      beforeEach(function() {
+        this.fsWriteStub = m.sinon.stub(fs, 'write');
+        const error = new Error('ENOENT: no such file or directory, write');
+        error.code = 'ENOENT';
+        this.fsWriteStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsWriteStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENOENT error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENOENT');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENOENT error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENOENT');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('given fs.write throws "EIO: i/o error, write"', function() {
+
+      beforeEach(function() {
+        this.fsWriteStub = m.sinon.stub(fs, 'write');
+        const error = new Error('EIO: i/o error, write');
+        error.code = 'EIO';
+        this.fsWriteStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsWriteStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an EIO error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EIO');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an EIO error', function(done) {
+          filesystem.writeChunk(this.fileDescriptor, Buffer.alloc(512, 1), 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EIO');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('.readChunk()', function() {
+
+    describe('given fs.read throws "ENXIO: no such device or address, read"', function() {
+
+      beforeEach(function() {
+        this.fsReadStub = m.sinon.stub(fs, 'read');
+        const error = new Error('ENXIO: no such device or address, read');
+        error.code = 'ENXIO';
+        this.fsReadStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsReadStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENXIO error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENXIO');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENXIO error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENXIO');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('given fs.read throws "ENOENT: no such file or directory, read"', function() {
+
+      beforeEach(function() {
+        this.fsReadStub = m.sinon.stub(fs, 'read');
+        const error = new Error('ENOENT: no such file or directory, read');
+        error.code = 'ENOENT';
+        this.fsReadStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsReadStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENOENT error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENOENT');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an ENOENT error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('ENOENT');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('given fs.read throws "EIO: i/o error, read"', function() {
+
+      beforeEach(function() {
+        this.fsReadStub = m.sinon.stub(fs, 'read');
+        const error = new Error('EIO: i/o error, read');
+        error.code = 'EIO';
+        this.fsReadStub.yields(error);
+      });
+
+      afterEach(function() {
+        this.fsReadStub.restore();
+      });
+
+      describe('given the current os is darwin', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('darwin');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an EIO error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EIO');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is linux', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('linux');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an unplugged error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EUNPLUGGED');
+            done();
+          });
+        });
+
+      });
+
+      describe('given the current os is win32', function() {
+
+        beforeEach(function() {
+          this.osPlatformStub = m.sinon.stub(os, 'platform');
+          this.osPlatformStub.returns('win32');
+        });
+
+        afterEach(function() {
+          this.osPlatformStub.restore();
+        });
+
+        it('should yield back an EIO error', function(done) {
+          filesystem.readChunk(this.fileDescriptor, 512, 1024, (error) => {
+            m.chai.expect(error).to.be.an.instanceof(Error);
+            m.chai.expect(error.code).to.equal('EIO');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -87,6 +87,8 @@ describe('Utils', function() {
         }
       });
 
+      this.timeout(10000);
+
       setTimeout(() => {
         input.emit('error', new Error('Input error'));
       }, 1);


### PR DESCRIPTION
In Windows, this error is ENOENT, in macOS, the error is ENXIO, and in
GNU/Linux, the error is EIO.

See: https://github.com/resin-io/etcher/issues/1124
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>