### PR TITLE
Get rid of the diskpart module

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -17,17 +17,34 @@
 'use strict';
 
 const Promise = require('bluebird');
+const tmp = Promise.promisifyAll(require('tmp'));
+const fs = Promise.promisifyAll(require('fs'));
+const debug = require('debug')(require('../package.json').name);
 const retry = require('bluebird-retry');
+const childProcess = Promise.promisifyAll(require('child_process'));
 const os = require('os');
 const _ = require('lodash');
 
+tmp.setGracefulCleanup();
+debug.log = console.log.bind(console);
+
 const runDiskpartScript = (script) => {
-  return Promise.try(() => {
-    if (os.platform() === 'win32') {
-      const diskpart = Promise.promisifyAll(require('diskpart'));
-      return diskpart.evaluateAsync(script).delay(2000);
-    }
-  });
+  if (os.platform() !== 'win32') {
+    return Promise.resolve();
+  }
+
+  return tmp.fileAsync().tap((temporaryPath) => {
+    return fs.writeFileAsync(temporaryPath, _.join(script, '\n'));
+  }).then((temporaryPath) => {
+    return childProcess.execAsync(`diskpart /s "${temporaryPath}"`);
+  }).then((stdout, stderr) => {
+    debug('stderr: %s', stderr);
+    debug('stdout: %s', stdout);
+
+  // Windows needs some time after the diskpart script is executed
+  // to reflect the changes. This mainly happened in Windows 10.
+  // An empirically derived value that seems to be enough is 2s.
+  }).delay(2000);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,17 +40,14 @@
     "jsdoc-to-markdown": "^2.0.1",
     "mocha": "^3.2.0",
     "mochainon": "^1.0.0",
-    "tmp": "0.0.31",
     "versionist": "^2.8.1"
-  },
-  "optionalDependencies": {
-    "diskpart": "^1.0.2"
   },
   "dependencies": {
     "bluebird": "^3.4.7",
     "bluebird-retry": "^0.10.1",
     "bmapflash": "^1.2.1",
     "crc32-stream": "^1.0.1",
+    "debug": "^2.6.6",
     "dev-null-stream": "0.0.1",
     "drivelist": "^5.0.14",
     "error": "^7.0.2",
@@ -58,6 +55,7 @@
     "progress-stream": "^1.2.0",
     "slice-stream2": "^2.0.1",
     "stream-chunker": "^1.2.8",
-    "through2": "^2.0.3"
+    "through2": "^2.0.3",
+    "tmp": "0.0.31"
   }
 }

--- a/tests/win32.spec.js
+++ b/tests/win32.spec.js
@@ -18,6 +18,7 @@
 
 const m = require('mochainon');
 const os = require('os');
+const childProcess = require('child_process');
 const win32 = require('../lib/win32');
 
 if (os.platform() === 'win32') {
@@ -28,19 +29,17 @@ if (os.platform() === 'win32') {
 
       this.timeout(30000);
 
-      const diskpart = require('diskpart');
-
-      describe('given diskpart always fails', function() {
+      describe('given the diskpart child process always fails', function() {
 
         beforeEach(function() {
-          this.diskpartEvaluateStub = m.sinon.stub(diskpart, 'evaluate');
+          this.childProcessExecStub = m.sinon.stub(childProcess, 'exec');
           const error = new Error('diskpart failure');
           error.code = 'EPERM';
-          this.diskpartEvaluateStub.yields(error);
+          this.childProcessExecStub.yields(error);
         });
 
         afterEach(function() {
-          this.diskpartEvaluateStub.restore();
+          this.childProcessExecStub.restore();
         });
 
         it('should yield an informational error message', function() {


### PR DESCRIPTION
The module is simple enough to inline it here, plus allows us to get rid
of the last optional dependency that is causing so much problems when
attempting to validate the shrinkwrap file.

See: https://github.com/resin-io/etcher/pull/1379
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>